### PR TITLE
Remove any function name for valid .js and in function (doc) format for couch

### DIFF
--- a/src/erica_macros.erl
+++ b/src/erica_macros.erl
@@ -14,7 +14,7 @@
 
 process_macros(Doc, AppDir) ->
     Funs = [<<"shows">>, <<"lists">>, <<"updates">>, <<"filters">>,
-        <<"spatial">>, <<"validate_update_doc">>],
+        <<"spatial">>, <<"validate_doc_update">>],
     %% apply macros too functions
     {Doc1, Objects} = process_macros_fun(Funs, Doc, [], Doc, AppDir),
     {Doc2, FinalObjects} = case couchbeam_doc:get_value(<<"views">>, Doc1) of


### PR DESCRIPTION
A fix for #28. Strips out any function name from the js file so couch does not consider it invalid. 
