### PR TITLE
Remove any function name for valid .js and in function (doc) format for couch

### DIFF
--- a/src/erica_macros.erl
+++ b/src/erica_macros.erl
@@ -14,7 +14,7 @@
 
 process_macros(Doc, AppDir) ->
     Funs = [<<"shows">>, <<"lists">>, <<"updates">>, <<"filters">>,
-        <<"spatial">>, <<"validate_update_doc">>],
+        <<"spatial">>, <<"validate_doc_update">>],
     %% apply macros too functions
     {Doc1, Objects} = process_macros_fun(Funs, Doc, [], Doc, AppDir),
     {Doc2, FinalObjects} = case couchbeam_doc:get_value(<<"views">>, Doc1) of
@@ -46,8 +46,9 @@ process_macros_fun([Prop|Rest], Obj, Objects, Doc, AppDir) ->
         undefined ->
             process_macros_fun(Rest, Obj, Objects, Doc, AppDir);
         Source when is_binary(Source) ->
+            Source0 = remove_function_name(Source),
             ?DEBUG("process function ~p~n", [Prop]),
-            Source1 = apply_macros(Source, Doc, AppDir),
+            Source1 = apply_macros(Source0, Doc, AppDir),
             Obj1 = couchbeam_doc:set_value(Prop, Source1, Obj),
             Objects1 = if Source =/= Source1 ->
                     SourceId = get_source_id(Source1),
@@ -60,7 +61,8 @@ process_macros_fun([Prop|Rest], Obj, Objects, Doc, AppDir) ->
         {Sources} ->
             ?DEBUG("process function ~p ~n", [Prop]),
             Sources1 = lists:foldl(fun({Fun1, Source}, Acc) ->
-                    Source1 = apply_macros(Source, Doc, AppDir),
+                    Source0 = remove_function_name(Source),
+                    Source1 = apply_macros(Source0, Doc, AppDir),
                     Parsed = if Source =/= Source1 ->
                             SourceId = get_source_id(Source1),
                             {Fun1, Source1, SourceId,
@@ -222,3 +224,7 @@ get_value([Name|_], Obj, _Len, _Count) ->
 get_source_id(Source) ->
     lists:flatten([io_lib:format("~.16b",[N])
             || N <-binary_to_list(crypto:md5(Source))]).
+
+remove_function_name(Source) ->
+    re:replace(Source, "^\s*function\s+[^(]*", "function ", [ multiline, caseless, {return, binary}]).
+


### PR DESCRIPTION
This allows for function names to be used in .js files to make them valid javascript.
This commit also includes a fix so validate_doc_update will be processed.

Applying this patch will solve #28.
