### PR TITLE
make standalone escript erica.cmd on Windows

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,12 +34,16 @@ main(Args) ->
             ++ load_files("priv/web_static/*", ".")
             ++ load_files("priv/web_templates/*", "."),
 
+    %% On Windows the shebang is different, and the filename needs a suffix
+    Filename = script_suffix("erica"),
+    Header = escript_header(),
+
     case zip:create("mem", Files, [memory]) of
         {ok, {"mem", ZipBin}} ->
             %% Archive was successfully created. Prefix that binary with our
             %% header and write to "rebar" file
-            Script = <<"#!/usr/bin/env escript\n%%! -pa . -noshell -noinput -sasl errlog_type error\n", ZipBin/binary>>,
-            case file:write_file("erica", Script) of
+            Script = <<Header/binary, ZipBin/binary>>,
+            case file:write_file(Filename, Script) of
                 ok ->
                     ok;
                 {error, WriteError} ->
@@ -52,14 +56,15 @@ main(Args) ->
     end,
 
     %% Finally, update executable perms for our script
-    {ok, #file_info{mode = Mode}} = file:read_file_info("erica"),
-    ok = file:change_mode("erica", Mode bor 8#00100),
+    {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
+    ok = file:change_mode(Filename, Mode bor 8#00100),
 
     %% Add a helpful message
-    io:format("Congratulations! You now have a self-contained script called \"erica\" in\n"
-              "your current working directory. Place this script anywhere in your path\n"
-              "and you can use build and push your design docs and docs
-              like erica.\n").
+
+    io:format("Congratulations! You now have a self-contained script called '~s'~n"
+              "in your current working directory. Place this script anywhere "
+              "in your path\nand you can use, build and push your docs and "
+              "design docs with erica.\n", [Filename]).
 
 load_files(Wildcard, Dir) ->
     lists:foldl(fun(Filename, Acc) ->
@@ -84,4 +89,29 @@ read_file(Filename, Dir) ->
         false ->
             {ok, Bin} = file:read_file(filename:join(Dir, Filename)),
             {Filename, Bin}
+    end.
+
+
+escript_header() -> 
+    Shebang = case os:type() of
+    {win32,_} ->
+        %% set local environment so that path is clean on exit
+        %% prepend path to same directory as script to allow loading DLLs
+        %% start escript using the same script as entry point and append args
+        %% on return from escript skip to end of .cmd file
+        <<"@echo off & ",
+        "setlocal & ",
+        "path=%~dp0;%path%; & ",
+        "escript.exe \"%~dpn0.cmd\" %*",
+        " & goto :eof\r\n">>;
+    _ ->
+        %% must be a unix variant
+        <<"#!/usr/bin/env escript\n">>
+    end,
+    %% Erlang VM args are the same across platforms, and must occur in L2 or L3
+    <<Shebang/binary, "%%! -pa . -noshell -noinput -sasl errlog_type error\n">>.
+
+script_suffix(Prefix) -> case os:type() of
+    {win32, _ } -> Prefix ++ ".cmd";
+    _           -> Prefix
     end.

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,2 +1,4 @@
 @echo off
-escript.exe bootstrap %*
+call rebar get-deps
+echo %%%% >> deps/proper/include/compile_flags.hrl
+call rebar compile

--- a/erica.bat
+++ b/erica.bat
@@ -1,4 +1,0 @@
-@echo off
-set erlca=%0
-escript.exe %erlca:.bat=% %*
-

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,8 @@
 
 {deps, [
     %% couchbeam client
-    {couchbeam, ".*", {git, "http://github.com/benoitc/couchbeam.git","master"}}
+    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git","master"}}
 ]}.
 
-{post_hooks, [{compile, "./bootstrap"}]}.
+%% following line requires R15B02 on Windows to work
+{post_hooks, [{compile, "escript bootstrap"}]}.


### PR DESCRIPTION
Could do with a good check, I made a number of small changes all over the place.
- set suffix of filename if on Windows
- use different shebang syntax across platforms
- use git:// URLs as git on Windows seems to prefer them
- call bootstrap via escript as ./bootstrap is not cross-platform
- include work-around for proper expecting make support on windows by touching compile_flags.hrl

NB still requires a dummy make somewhere in your system, or using mingw etc. for proper.

echo [make] %\* > make.cmd

I have a fix for this & will send it upstream, so should be a non-issue in the near future.

fix sent through to proper team, https://github.com/manopapad/proper/pull/51
