### PR TITLE
Remove the _couchdb rewrite to work with secure_rewrites

### DIFF
--- a/priv/templates/webstyle/_ddoc/rewrites.json
+++ b/priv/templates/webstyle/_ddoc/rewrites.json
@@ -3,8 +3,6 @@
     { "from": "_db/*" , "to"  : "../../*" },
     { "description": "Access to this design document" , "from": "_ddoc" , "to"  : "" },
     { "from": "_ddoc/*" , "to"  : "*"},
-    { "description": "Access to the main CouchDB API", "from": "_couchdb" , "to"  : "../../.."},
-    { "from": "_couchdb/*" , "to"  : "../../../*"},
     { "from": "/", "to": "index.html"},
     { "from": "/*", "to": "*"}
 ]


### PR DESCRIPTION
Fixes issue #42. 

This makes so secure_rewrites can be true. on the target couch.
