### PR TITLE
Correct couchbeam git URL to read only version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,6 @@
 
 {deps, [
     %% couchbeam client
-    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git",
+    {couchbeam, ".*", {git, "https://github.com/benoitc/couchbeam.git",
                       {branch, "erica"}}}
 ]}.


### PR DESCRIPTION
When make-ing erica it attempts to clone couchbeam from the read/write git url, which only works if you have permissions on that repo. This commit changes the couchbeam url to the read-only (https) version. Thanks.
