### PR TITLE
Match requirements to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and web applications (couchapps), and generally get files to couchdb.
 
 ##Requirements
 
-* Erlang R14 or sup
+* Erlang R15B01 (or higher) with crypto support
 * gcc
 
 ##Installation


### PR DESCRIPTION
The requirements section listed the wrong version of Erlang.
