### PR TITLE
Handle unrecognized file mimetypes

### DIFF
--- a/src/erica_push.erl
+++ b/src/erica_push.erl
@@ -369,6 +369,13 @@ guess_mime(File) ->
 
 from_extension(".webapp") ->
     "application/x-web-app-manifest+json";
+
+from_extension(".webm") ->
+    "video/webm";
+
+from_extension(".mp4") ->
+    "video/mp4";
+
 from_extension(_) ->
     undefined.
 


### PR DESCRIPTION
Hello,

Mimes for .mp4 and .web videos seemed unhandled (they were referenced in couch as 'text/plain' thus, html5 video streaming in Firefox was not working.

I added this small hack, i think it shall be handled differently but in the meantime this works.

Thank you for your excellent work on erica.

gbuisson. 
