### PR TITLE
couchbeam clone url on install

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,6 @@
 
 {deps, [
     %% couchbeam client
-    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git",
+    {couchbeam, ".*", {git, "https://github.com/benoitc/couchbeam.git",
                       {branch, "erica"}}}
 ]}.


### PR DESCRIPTION
same as pull request 44 (@ddgenome makes a good point)
- in the far most cases port 9418 (git://) is blocked by the firewall
- some people give up on receiving the error message:
  <pre>
  ERROR: git clone -n git://github.com/benoitc/couchbeam.git 
  couchbeam failed with error: 128 and output:
  fatal: unable to connect to github.com
  </pre>
  so using `https://` lowers the threshold
- I do not think that `git://` is more reliable than `https://` in this case
