### PR TITLE
Workaround for named nested functions.

### DIFF
--- a/src/erica_macros.erl
+++ b/src/erica_macros.erl
@@ -226,5 +226,5 @@ get_source_id(Source) ->
             || N <-binary_to_list(crypto:md5(Source))]).
 
 remove_function_name(Source) ->
-    re:replace(Source, "^\s*function\s+[^(]*", "function ", [ multiline, caseless, {return, binary}]).
+    re:replace(Source, "^function\s+[^(]*", "function ", [ multiline, caseless, {return, binary}]).
 


### PR DESCRIPTION
I have trouble using nested function declarations inside validate_doc_update, because every "function helper(doc)" is stripped down to "function(doc)" and syntax is rendered invalid. My suggestion would be to apply substitution only to functions at the beginning of a line. I mean who on earth would write "[space][space][space][space]function map(doc) {"???

Cheerio
Oscar
