### PR TITLE
Updated readme with apt commands for dependency installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ of CouchDB.
 
 ####Installing Dependencies on Debian/Ubuntu
 
-    sudo apt-get install rebar erlang-src
+    sudo apt-get install rebar erlang-src erlang-xmerl
 
 ##Download
 


### PR DESCRIPTION
I got hung up on the ibrowse install due to the error:  can't find include lib "kernel/src/inet_dns.hrl". Thought I would update the readme to help others avoid the same slow down.
