### PR TITLE
add more explicitly the requirement of erlang-src to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ of CouchDB.
 * gcc
 * [rebar](https://github.com/rebar/rebar)
 * git
+* erlang-src
 
 ####Installing Dependencies on Debian/Ubuntu
 


### PR DESCRIPTION
```
geändert:   README.md
```
