### PR TITLE
The package leex moved in Ubuntu 13.10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ of CouchDB.
 
 ####Installing Dependencies on Debian/Ubuntu
 
-    sudo apt-get install rebar erlang-src erlang-xmerl
+    sudo apt-get install rebar erlang-src erlang-xmerl erlang-parsetools
 
 ##Download
 


### PR DESCRIPTION
Needed for mimetypes compile.
