### PR TITLE
Update couchbeam dep to 1.1.3

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -11,7 +11,6 @@ main(Args) ->
     true = code:add_path("deps/mochiweb/ebin"),
     true = code:add_path("deps/jsx/ebin"),
     true = code:add_path("deps/idna/ebin"),
-    true = code:add_path("deps/hackney_lib/ebin"),
     true = code:add_path("deps/hackney/ebin"),
     true = code:add_path("deps/oauth/ebin"),
     true = code:add_path("deps/couchbeam/ebin"),
@@ -30,7 +29,6 @@ main(Args) ->
             ++ load_files("*", "deps/hackney/ebin")
             ++ load_files("*", "deps/jsx/ebin")
             ++ load_files("*", "deps/idna/ebin")
-            ++ load_files("*", "deps/hackney_lib/ebin")
             ++ load_files("*", "deps/hackney/ebin")
             ++ load_files("*", "deps/oauth/ebin")
             ++ load_files("*", "deps/couchbeam/ebin")

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
     %% couchbeam client
     {couchbeam, ".*", {git, "https://github.com/benoitc/couchbeam.git",
-                       {tag, "1.0.5"}}}
+                       {tag, "1.1.3"}}}
 ]}.

--- a/src/erica_util.erl
+++ b/src/erica_util.erl
@@ -6,7 +6,7 @@
 -module(erica_util).
 
 -include_lib("hackney/include/hackney.hrl").
--include_lib("hackney_lib/include/hackney_lib.hrl").
+-include_lib("hackney/include/hackney_lib.hrl").
 -include_lib("erica/include/erica.hrl").
 
 -define(BLOCKSIZE, 32768).


### PR DESCRIPTION
This also drops dependency from deprecated hackney_lib.
