### PR TITLE
Create arbitrary doc id with push command, fixes #86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ erica
 *.gz
 distdir
 erica.cmd
+
+**~
+**#

--- a/src/erica_push.erl
+++ b/src/erica_push.erl
@@ -172,26 +172,26 @@ has_index_file(#couchapp{attachments=List}) ->
    end, List).
 
 id_from_path(Path, Config) ->
-    IdFile = filename:join(Path, "_id"),
-    case filelib:is_regular(IdFile) of
-        true ->
-            {ok, Bin} = file:read_file(IdFile),
-            [Id|_] = binary:split(Bin, [<<"\n">>, <<"\r\n">>], [trim]),
-            Id;
-        false ->
-            case erica_config:get(Config, docid) of
-                undefined ->
+    case erica_config:get(Config, docid) of
+		undefined ->
+			IdFile = filename:join(Path, "_id"),
+			case filelib:is_regular(IdFile) of
+				true ->
+					{ok, Bin} = file:read_file(IdFile),
+					[Id|_] = binary:split(Bin, [<<"\n">>, <<"\r\n">>], [trim]),
+					Id;
+				false ->
                     Fname = list_to_binary(filename:basename(Path)),
                     case erica_config:get(Config, is_ddoc) of
                         true ->
                             <<"_design/", Fname/binary>>;
                         false ->
                             Fname
-                    end;
-                DocId ->
-                    DocId
-            end
-    end.
+                    end
+			end;
+		DocId ->
+			erlang:list_to_binary(DocId)
+	end.
 
 couchapp_from_fs(#couchapp{ddoc_dir=DdocPath}=Couchapp) ->
     Couchapp1 = attachments_from_fs(Couchapp),


### PR DESCRIPTION
The function `erica_push:id_from_path/2` originally didn't accept arbitrary doc id (--docid argument) if _id file is present. Also, the value of `--docid` argument was not converted into the binary.

This patch enables the following rules in assigning the doc id by the push command:
1. if `--docid` argument is provided then its value is used as doc id. The argument `--is-ddoc` does not affect this decision
2. if --docid argument is not provided but `_id` file is present in the directory that is given as the push command argument, then the content of the _id file is used as doc id. The argument `--is-ddoc` does not affect this decision
3. if `--docid` argument is not provided and `_id` file is missing in the directory that is given as the push command argument, then the name of the directory is used as the doc id if argument `--is-ddoc` is set to false. Otherwise, the name of the directory is prefixed with string "_design/" and that is used as doc id.
