### PR TITLE
modify to work in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,29 +14,29 @@ install: all
 	@install -m 0755 -c erica $(PREFIX)/erica
 
 compile:
-	@./rebar compile
-	@escript bootstrap
+	@escript.exe rebar compile
+	@escript.exe bootstrap
 
 deps:
-	@./rebar get-deps
+	@escript.exe rebar get-deps
 
 doc:
-	@./rebar doc
+	@escript.exe rebar doc
 
 clean:
-	@./rebar clean
+	@escript.exe rebar clean
 	@rm -f erica erica.cmd
 
 distclean: clean
-	@./rebar delete-deps
+	@escript.exe rebar delete-deps
 
 upgrade: distclean all
 
 update: clean
-	@./rebar update-deps
-	@./rebar get-deps
-	@./rebar compile
-	@escript bootstrap
+	@escript.exe rebar update-deps
+	@escript.exe rebar get-deps
+	@escript.exe rebar compile
+	@escript.exe bootstrap
 
 ##
 ## release tarballs

--- a/rebar.config
+++ b/rebar.config
@@ -6,10 +6,10 @@
 
 {deps, [
      %% couchbeam client
-    {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git",
+    {mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git",
                       "v2.7.0 "}},
 
     %% couchbeam client
-    {couchbeam, ".*", {git, "https://github.com/benoitc/couchbeam.git",
+    {couchbeam, ".*", {git, "git://github.com/benoitc/couchbeam.git",
                        {tag, "1.1.8"}}}
 ]}.


### PR DESCRIPTION
the modifications made here are incomplete and platform specific.

- installed erlang R14B04 http://www.erlang.org/download/otp_win32_R14B04.exe
- encountered the same error as described in http://erlang.org/pipermail/erlang-questions/2011-June/059155.html
- solution: http://www.francolombardo.net/escript-under-windows_post-107.html
- i modified the makefile accordingly: https://github.com/jeremytammik/erica/commit/f58643a715983feab9a14466836050abbbf8e28c
- encountered issue with https described here: https://github.com/juj/emsdk/issues/13
- resolved it by replacing prefix https:// by git://
- my modifications in commit: https://github.com/jeremytammik/erica/commit/7335c8e67a94bf2faa018bdb419ad2aa7a6798e4
